### PR TITLE
Change form field for tar file to align with new name in core

### DIFF
--- a/utils/send-command.js
+++ b/utils/send-command.js
@@ -22,7 +22,7 @@ async function sendCommand({
     }
 
     if (file) {
-        form.append('filedata', createReadStream(resolvePath(file).pathname));
+        form.append('package', createReadStream(resolvePath(file).pathname));
     }
 
     if (map) {


### PR DESCRIPTION
Makes the client align with https://github.com/eik-lib/core/pull/62. This will probably break tests until core is published with the new field name.