### PR TITLE
allow not specifying exact npm version for a dependency

### DIFF
--- a/commands/dependency.js
+++ b/commands/dependency.js
@@ -7,7 +7,7 @@ const av = require('yargs-parser')(process.argv.slice(2))
 const PublishDependency = require('../classes/publish/dependency');
 const { resolvePath, logger, readMetaFile } = require('../utils');
 
-exports.command = 'dependency <name> <version>';
+exports.command = 'dependency <name> [<version>]';
 
 exports.aliases = ['dep'];
 


### PR DESCRIPTION
This PR makes it possible to publish an npm dependency without specifying a version (which will then default to latest)

With this PR the following 2 examples are both valid

```sh
eik dependency lodash
```

```sh
eik dependency lodash 4.17.0
```