### PR TITLE
Improve publish command output

### DIFF
--- a/classes/publish/npm.js
+++ b/classes/publish/npm.js
@@ -354,6 +354,7 @@ module.exports = class PublishDependency {
         this.log.info(
             `Published npm package "${this.name}" at version "${this.version}"`,
         );
-        return true;
+
+        return this.version;
     }
 };

--- a/classes/publish/package/index.js
+++ b/classes/publish/package/index.js
@@ -91,6 +91,6 @@ module.exports = class PublishApp {
             );
         }
 
-        return true;
+        return this.nextVersion;
     }
 };

--- a/commands/meta.js
+++ b/commands/meta.js
@@ -4,13 +4,11 @@
 
 'use strict';
 
-const chalk = require('chalk');
 const { readFileSync } = require('fs');
-const { join } = require('path');
 const ora = require('ora');
-const formatDistance = require('date-fns/formatDistance');
 const av = require('yargs-parser')(process.argv.slice(2))
 const Meta = require('../classes/meta');
+const Artifact = require('../utils/artifact');
 const { resolvePath, logger } = require('../utils');
 
 exports.command = 'meta <name>';
@@ -55,72 +53,6 @@ exports.builder = (yargs) => {
     });
 };
 
-function readableBytes(bytes) {
-    const i = Math.floor(Math.log(bytes) / Math.log(1024)),
-    sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
-    return (bytes / Math.pow(1024, i)).toFixed(2) * 1 + ' ' + sizes[i];
-}
-
-function colorType(type) {
-    if (type === 'npm') {
-        return chalk.white.bgRed.bold(' NPM ');
-    }
-    
-    if (type === 'pkg') {
-        return chalk.white.bgYellow.bold(' PACKAGE ');
-    }
-
-    return chalk.white.bgBlue.bold(' IMPORT MAP ')
-}
-
-function formatMeta({ name, type, versions, org } = {}, server) {
-    const metaUrl = new URL(join(type, name), server);
-    const write = process.stdout.write.bind(process.stdout);
-
-    write(`:: ${colorType(type)} > ${chalk.green(name)} | `);
-    write(`${chalk.bold('org:')} ${org} | `);
-    write(`${chalk.bold('url:')} ${chalk.cyan(metaUrl.href)}\n`);
-
-    if (versions.length) {
-        write(`\n   ${chalk.bold('versions:')}\n`);
-    }
-
-    for (const { version, integrity, created, author, files } of versions) {
-        const baseUrl = new URL(join(metaUrl.pathname, version), server);
-        write(`   - ${chalk.green(version)}\n`);
-        write(`     ${chalk.bold('url:')} ${chalk.cyan(baseUrl.href)}\n`);
-
-        write(`     ${chalk.bold('integrity:')} ${integrity}\n`);
-
-        if (files) {
-            write(`\n     ${chalk.bold('files:')}\n`);
-            for (const file of files) {
-                const fileUrl = new URL(join(baseUrl.pathname, file.pathname), server);
-                write(`     - ${chalk.cyan(fileUrl.href)} `);
-                write(`${chalk.yellow(file.mimeType)} `);
-                write(`${chalk.magenta(readableBytes(file.size))}\n`);
-                write(`       ${chalk.bold('integrity:')} ${file.integrity}\n\n`);
-            }
-        }
-
-        if (created) {
-            const d = formatDistance(
-                new Date(created * 1000),
-                new Date(),
-                { addSuffix: true }
-            );
-            write(`     ${chalk.bold('published')} ${chalk.yellow(d)}`);
-        }
-
-        if (author) {
-            write(` ${chalk.bold('by')} ${chalk.yellow(author.name)}`);
-        }
-
-        write(`\n`);
-        
-    }
-}
-
 exports.handler = async (argv) => {
     const spinner = ora({ stream: process.stdout }).start('working...');
     let meta = false;
@@ -141,7 +73,8 @@ exports.handler = async (argv) => {
         spinner.stopAndPersist();
         
         for (const m of Object.values(meta)) {
-            formatMeta(m, server);
+            const artifact = new Artifact(m);
+            artifact.format(server);
             process.stdout.write(`\n`);
         }
 

--- a/test/publish.npm.test.js
+++ b/test/publish.npm.test.js
@@ -48,7 +48,7 @@ test('Uploading a dependency to an asset server', async t => {
 
     const result = await publishDep.run();
 
-    t.equals(result, true, 'Command should return true');
+    t.equals(result, '1.1.2', 'Command should return true');
     t.match(
         l.logs.debug,
         ':: npm lit-html v1.1.2',
@@ -76,7 +76,7 @@ test('Uploading a dependency with @ character in name', async t => {
 
     const result = await publishDep.run();
 
-    t.equals(result, true, 'Command should return true');
+    t.equals(result, '1.0.0-beta.2', 'Command should return true');
     t.match(
         l.logs.debug,
         ':: npm @podium/browser v1.0.0-beta.2',

--- a/test/publish.package.test.js
+++ b/test/publish.package.test.js
@@ -42,7 +42,6 @@ test('Uploading app assets to an asset server', async t => {
         cwd: __dirname,
         server: address,
         name: 'my-app',
-        version: '1.0.0',
         js: './fixtures/client.js',
         css: './fixtures/styles.css',
         debug: true,
@@ -50,7 +49,7 @@ test('Uploading app assets to an asset server', async t => {
     });
 
     const result = await publishApp.run();
-    t.equals(result, true, 'Command should return true');
+    t.equals(result, '1.0.0', 'Command should return true');
     t.match(
         l.logs.debug,
         ':: pkg my-app v1.0.0',
@@ -72,14 +71,13 @@ test('Uploading JS app assets only to an asset server', async t => {
         cwd: __dirname,
         server: address,
         name: 'my-app',
-        version: '1.0.0',
         js: './fixtures/client.js',
         debug: true,
         token,
     });
 
     const result = await publishApp.run();
-    t.equals(result, true, 'Command should return true');
+    t.equals(result, '1.0.0', 'Command should return true');
     t.match(
         l.logs.debug,
         'CSS entrypoint not defined, skipping CSS bundling',
@@ -101,14 +99,13 @@ test('Uploading CSS app assets only to an asset server', async t => {
         cwd: __dirname,
         server: address,
         name: 'my-app',
-        version: '1.0.0',
         css: './fixtures/styles.css',
         debug: true,
         token,
     });
 
     const result = await publishApp.run();
-    t.equals(result, true, 'Command should return true');
+    t.equals(result, '1.0.0', 'Command should return true');
     t.match(
         l.logs.debug,
         'JavaScript entrypoint not defined, skipping JS bundling',

--- a/utils/artifact.js
+++ b/utils/artifact.js
@@ -1,0 +1,94 @@
+/* eslint-disable no-underscore-dangle */
+
+'use strict';
+
+const {join} = require('path');
+const chalk = require('chalk');
+const Version = require('./version');
+
+const _name = Symbol('name');
+const _type = Symbol('type');
+const _org = Symbol('org');
+const _versions = Symbol('versions');
+
+function colorType(type) {
+    if (type === 'npm') {
+        return chalk.white.bgRed.bold(' NPM ');
+    }
+    
+    if (type === 'pkg') {
+        return chalk.white.bgYellow.bold(' PACKAGE ');
+    }
+
+    return chalk.white.bgBlue.bold(' IMPORT MAP ')
+}
+
+class Artifact {
+    constructor({
+        type = '',
+        name = '',
+        org = '',
+        versions = [],
+    } = {}) {
+        this.type = type;
+        this.name = name;
+        this.org = org;
+        this.versions = versions;
+    }
+
+    get type() {
+        return this[_type];
+    }
+
+    set type(type) {
+        this[_type] = type;
+    }
+
+    get name() {
+        return this[_name];
+    }
+
+    set name(name) {
+        this[_name] = name;
+    }
+
+    get org() {
+        return this[_org];
+    }
+    
+    set org(org) {
+        this[_org] = org;
+    }
+    
+    get versions() {
+        return this[_versions];
+    }
+    
+    set versions(versions) {
+        const v = [];
+        for (const version of versions) {
+            v.push(new Version(version, this.baseURL));
+        }
+        this[_versions] = v;
+    }
+
+    format (baseURL = '') {
+        const write = process.stdout.write.bind(process.stdout);
+        const url = new URL(join(this.type, this.name), baseURL);
+
+        write(`:: ${colorType(this.type)} > ${chalk.green(this.name)} | `);
+        write(`${chalk.bold('org:')} ${this.org} | `);
+        write(`${chalk.bold('url:')} ${chalk.cyan(url.href)}\n`);
+
+        if (this.versions.length) {
+            write(`\n   ${chalk.bold('versions:')}\n`);
+        }
+
+        for (const version of this.versions) {
+            version.format(url.href);
+            write(`\n`);
+        }
+    }
+}
+
+module.exports = Artifact;

--- a/utils/index.js
+++ b/utils/index.js
@@ -14,6 +14,7 @@ const incrementSemverVersion = require('./increment-semver-version');
 const writeMetaFile = require('./write-meta-file');
 const readMetaFile = require('./read-meta-file');
 const compressedSize = require('./compressed-size');
+const Artifact = require('./artifact');
 
 module.exports = {
     resolvePath,
@@ -30,4 +31,5 @@ module.exports = {
     writeMetaFile,
     readMetaFile,
     compressedSize,
+    Artifact,
 };

--- a/utils/version.js
+++ b/utils/version.js
@@ -1,0 +1,158 @@
+/* eslint-disable no-restricted-properties */
+/* eslint-disable prefer-template */
+/* eslint-disable one-var */
+/* eslint-disable no-underscore-dangle */
+
+'use strict';
+
+const {join} = require('path');
+const chalk = require('chalk');
+const formatDistance = require('date-fns/formatDistance');
+
+const _integrity = Symbol('integrity');
+const _version = Symbol('type');
+const _author = Symbol('author');
+const _created = Symbol('created');
+const _type = Symbol('type');
+const _name = Symbol('name');
+const _org = Symbol('org');
+const _files = Symbol('files');
+const _meta = Symbol('meta');
+
+function readableBytes(bytes) {
+    const i = Math.floor(Math.log(bytes) / Math.log(1024)),
+    sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+    return (bytes / Math.pow(1024, i)).toFixed(2) * 1 + ' ' + sizes[i];
+}
+
+class Version {
+    constructor({
+        version = '',
+        integrity = '',
+        author = {},
+        created = null,
+        type = '',
+        name = '',
+        org = '',
+        files = [],
+        meta = [],
+    } = {}) {
+        this.version = version;
+        this.integrity = integrity;
+        this.author = author;
+        this.created = created;
+        this.type = type;
+        this.name = name;
+        this.org = org;
+        this.files = files;
+        this.meta = meta;
+    }
+
+    get version() {
+        return this[_version];
+    }
+
+    set version(version) {
+        this[_version] = version;
+    }
+
+    get integrity() {
+        return this[_integrity];
+    }
+
+    set integrity(integrity) {
+        this[_integrity] = integrity;
+    }
+
+    get author() {
+        return this[_author];
+    }
+    
+    set author(author) {
+        this[_author] = author;
+    }
+
+    get created() {
+        return this[_created];
+    }
+    
+    set created(created) {
+        this[_created] = created;
+    }
+    
+    get type() {
+        return this[_type];
+    }
+    
+    set type(type) {
+        this[_type] = type;
+    }
+
+    get name() {
+        return this[_name];
+    }
+    
+    set name(name) {
+        this[_name] = name;
+    }
+
+    get org() {
+        return this[_org];
+    }
+    
+    set org(org) {
+        this[_org] = org;
+    }
+
+    get files() {
+        return this[_files];
+    }
+    
+    set files(files) {
+        this[_files] = files;
+    }
+
+    get meta() {
+        return this[_meta];
+    }
+    
+    set meta(meta) {
+        this[_meta] = meta;
+    }
+
+    format(baseURL = '') {
+        const write = process.stdout.write.bind(process.stdout);
+        const url = new URL(baseURL);
+        const bURL = new URL(join(url.pathname, this.version), url.origin);
+        
+        write(`   - ${chalk.green(this.version)}\n`);
+        write(`     ${chalk.bold('url:')} ${chalk.cyan(bURL.href)}\n`);
+        write(`     ${chalk.bold('integrity:')} ${this.integrity}\n`);
+
+        if (this.files) {
+            write(`\n     ${chalk.bold('files:')}\n`);
+            for (const file of this.files) {
+                const fileUrl = new URL(join(bURL.pathname, file.pathname), url.origin);
+                write(`     - ${chalk.cyan(fileUrl.href)} `);
+                write(`${chalk.yellow(file.mimeType)} `);
+                write(`${chalk.magenta(readableBytes(file.size))}\n`);
+                write(`       ${chalk.bold('integrity:')} ${file.integrity}\n\n`);
+            }
+        }
+
+        if (this.created) {
+            const d = formatDistance(
+                new Date(this.created * 1000),
+                new Date(),
+                { addSuffix: true }
+            );
+            write(`     ${chalk.bold('published')} ${chalk.yellow(d)}`);
+        }
+
+        if (this.author) {
+            write(` ${chalk.bold('by')} ${chalk.yellow(this.author.name)}`);
+        }
+    }
+}
+
+module.exports = Version;

--- a/utils/version.js
+++ b/utils/version.js
@@ -129,7 +129,7 @@ class Version {
         write(`     ${chalk.bold('url:')} ${chalk.cyan(bURL.href)}\n`);
         write(`     ${chalk.bold('integrity:')} ${this.integrity}\n`);
 
-        if (this.files) {
+        if (this.files && this.files.length) {
             write(`\n     ${chalk.bold('files:')}\n`);
             for (const file of this.files) {
                 const fileUrl = new URL(join(bURL.pathname, file.pathname), url.origin);
@@ -149,7 +149,7 @@ class Version {
             write(`     ${chalk.bold('published')} ${chalk.yellow(d)}`);
         }
 
-        if (this.author) {
+        if (this.author && this.author.name) {
             write(` ${chalk.bold('by')} ${chalk.yellow(this.author.name)}`);
         }
     }


### PR DESCRIPTION
This PR aligns command output with some nice coloured formatting to match the formatting of the meta command

**Output for the package command:**

<img width="833" alt="Screenshot 2020-05-06 at 21 43 01" src="https://user-images.githubusercontent.com/1177098/81169240-a0242a80-8fec-11ea-9a59-d0c60c3f7409.png">

**Output for the import map command:**

<img width="808" alt="Screenshot 2020-05-06 at 22 51 58" src="https://user-images.githubusercontent.com/1177098/81169249-a5817500-8fec-11ea-8880-d360b5278303.png">

**Output for the import npm command:**

<img width="823" alt="Screenshot 2020-05-06 at 22 52 41" src="https://user-images.githubusercontent.com/1177098/81169255-aa462900-8fec-11ea-9f72-386d5a2d8b96.png">
