### PR TITLE
Tweak package command

### DIFF
--- a/classes/meta.js
+++ b/classes/meta.js
@@ -33,7 +33,6 @@ module.exports = class Meta {
             const typeFetches = [];
             for (const type of types) {
                 const url = new URL(join(type, this.name), this.server);
-
                 typeFetches.push(fetch(url));
             }
 
@@ -53,7 +52,6 @@ module.exports = class Meta {
 
                     const vers = new Map(versions);
                     data[type].versions = Array.from(vers.values());
-
                     for (let i = 0; i < data[type].versions.length; i++) {
                         const { version } = data[type].versions[i];
                         const url = new URL(

--- a/classes/publish/package/index.js
+++ b/classes/publish/package/index.js
@@ -23,7 +23,7 @@ module.exports = class PublishApp {
         server,
         token,
         name,
-        major,
+        major = 1,
         level = 'patch',
         map = [],
         js,

--- a/commands/init.js
+++ b/commands/init.js
@@ -105,13 +105,9 @@ exports.handler = async (argv) => {
         );
 
         log.info(`"assets.json" successfully written to directory`);
-        spinner.text = '';
-        spinner.stopAndPersist();
     } catch (err) {
         log.warn(err.message);
-
-        spinner.text = '';
-        spinner.stopAndPersist();
-        process.exit(1);
     }
+    spinner.text = '';
+    spinner.stopAndPersist();
 };

--- a/commands/map-alias.js
+++ b/commands/map-alias.js
@@ -92,14 +92,9 @@ exports.handler = async (argv) => {
         log.warn(err.message);
     }
 
+    spinner.text = '';
+    spinner.stopAndPersist();
     if (success) {
-        spinner.text = '';
-        spinner.stopAndPersist();
-
         new AliasFormatter(data).format(server);
-    } else {
-        spinner.text = '';
-        spinner.stopAndPersist();
-        process.exit(1);
     }
 };

--- a/commands/map.js
+++ b/commands/map.js
@@ -95,6 +95,5 @@ exports.handler = async argv => {
         spinner.warn(err.message);
         spinner.text = '';
         spinner.stopAndPersist();
-        process.exit(1);
     }
 };

--- a/commands/meta.js
+++ b/commands/meta.js
@@ -71,11 +71,7 @@ exports.handler = async (argv) => {
             process.stdout.write(`\n`);
         }
 
-        spinner.text = '';
-        spinner.stopAndPersist();
-    } else {
-        spinner.text = '';
-        spinner.stopAndPersist();
-        process.exit(1);
     }
+    spinner.text = '';
+    spinner.stopAndPersist();
 };

--- a/commands/npm-alias.js
+++ b/commands/npm-alias.js
@@ -86,14 +86,9 @@ exports.handler = async (argv) => {
         log.warn(err.message);
     }
 
+    spinner.text = '';
+    spinner.stopAndPersist();
     if (success) {
-        spinner.text = '';
-        spinner.stopAndPersist();
-
         new AliasFormatter(data).format(server);
-    } else {
-        spinner.text = '';
-        spinner.stopAndPersist();
-        process.exit(1);
     }
 };

--- a/commands/npm.js
+++ b/commands/npm.js
@@ -139,6 +139,5 @@ exports.handler = async (argv) => {
         spinner.warn(err.message);
         spinner.text = '';
         spinner.stopAndPersist();
-        process.exit(1);
     }
 };

--- a/commands/package-alias.js
+++ b/commands/package-alias.js
@@ -90,14 +90,9 @@ exports.handler = async (argv) => {
         log.warn(err.message);
     }
 
+    spinner.text = '';
+    spinner.stopAndPersist();
     if (success) {
-        spinner.text = '';
-        spinner.stopAndPersist();
-
         af.format(server);
-    } else {
-        spinner.text = '';
-        spinner.stopAndPersist();
-        process.exit(1);
     }
 };

--- a/commands/package.js
+++ b/commands/package.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { promises: fs, constants } = require('fs');
 const { join } = require('path');
 const fetch = require('node-fetch');
 const ora = require('ora');
@@ -75,6 +76,12 @@ exports.handler = async (argv) => {
     const {name, server, map, js, css, major} = getDefaults(cwd);
 
     try {
+        try {
+            await fs.access(join(cwd, 'assets.json'), constants.F_OK);
+        } catch(err) {
+            throw new Error('No assets.json file found in the current working directory. Please run eik init');
+        }
+
         const options = { 
             logger: logger(spinner, debug),
             name,

--- a/commands/package.js
+++ b/commands/package.js
@@ -164,6 +164,5 @@ exports.handler = async (argv) => {
         spinner.warn(err.message);
         spinner.text = '';
         spinner.stopAndPersist();
-        process.exit(1);
     }
 };

--- a/commands/package.js
+++ b/commands/package.js
@@ -62,18 +62,11 @@ exports.builder = (yargs) => {
     yargs.default('token', defaults.token, defaults.token ? '######' : '');
 
     yargs.example(`eik package`);
+    yargs.example(`eik publish`);
     yargs.example(`eik package patch`);
-    yargs.example(`eik package minor --major 1`);
-    yargs.example(`eik package patch --major 1 --js ./assets/client.js --css ./assets/styles.css`);
-    yargs.example(`eik package patch --name my-app`);
-    yargs.example(`eik pkg patch --name my-app`);
-    yargs.example(`eik pkg --name my-app --server https://assets.myeikserver.com`);
-    yargs.example(`eik pkg --dry-run`);
+    yargs.example(`eik publish --dry-run`);
     yargs.example(`eik pkg --token ######`);
-    yargs.example(`eik pkg --map https://server/my-map1.json`);
-    yargs.example(`eik pkg --map https://server/my-map1.json --map https://server/my-map2.json`);
     yargs.example(`eik pkg --debug`);
-    yargs.example(`eik pkg -s https://assets.myeikserver.com -t ###### --name my-app --js ./assets/client.js --css ./assets/styles.css`);
 };
 
 exports.handler = async (argv) => {

--- a/commands/ping.js
+++ b/commands/ping.js
@@ -34,21 +34,14 @@ exports.builder = (yargs) => {
 
 exports.handler = async (argv) => {
     const spinner = ora({ stream: process.stdout }).start('working...');
-    let success = false;
     const { debug } = argv;
 
     try {
-        success = await new Ping({ logger: logger(spinner, debug) }).run();
+        await new Ping({ logger: logger(spinner, debug) }).run();
     } catch (err) {
         logger.warn(err.message);
     }
 
-    if (success) {
-        spinner.text = '';
-        spinner.stopAndPersist();
-    } else {
-        spinner.text = '';
-        spinner.stopAndPersist();
-        process.exit(1);
-    }
+    spinner.text = '';
+    spinner.stopAndPersist();
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eik/cli",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "description": "Cli tool for publishing assets",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "rollup": "^2.7.6",
     "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-esm-import-to-url": "^2.0.0",
+    "rollup-plugin-esm-import-to-url": "^2.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-terser": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eik/cli",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Cli tool for publishing assets",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eik/cli",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-beta.1",
   "description": "Cli tool for publishing assets",
   "main": "index.js",
   "bin": {

--- a/test/integration/package.test.js
+++ b/test/integration/package.test.js
@@ -52,6 +52,7 @@ test('eik package : package, details provided by assets.json file', async (t) =>
         js: { input: join(__dirname, '..', 'fixtures', 'client.js') },
         css: { input: join(__dirname, '..', 'fixtures', 'styles.css') },
     };
+
     await fs.writeFile(
         join(t.context.folder, 'assets.json'),
         JSON.stringify(assets),


### PR DESCRIPTION
* enforces the presence of an assets.json file in the CWD when using the package/publish command
* aliases package to publish so you can run `eik publish`
* removes command line arguments for `map`, `js`, `css`, `name` and `server` when running the package/publish command