### PR TITLE
Tweak package command2

### DIFF
--- a/classes/publish/package/index.js
+++ b/classes/publish/package/index.js
@@ -23,7 +23,7 @@ module.exports = class PublishApp {
         server,
         token,
         name,
-        major,
+        major = 1,
         level = 'patch',
         map = [],
         js,

--- a/commands/package.js
+++ b/commands/package.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { promises: fs, constants } = require('fs');
 const { join } = require('path');
 const fetch = require('node-fetch');
 const ora = require('ora');
@@ -75,6 +76,12 @@ exports.handler = async (argv) => {
     const {name, server, map, js, css, major} = getDefaults(cwd);
 
     try {
+        try {
+            await fs.access(join(cwd, 'assets.json'), constants.F_OK);
+        } catch(err) {
+            throw new Error('No assets.json file found in the current working directory. Please run eik init');
+        }
+
         const options = { 
             logger: logger(spinner, debug),
             name,

--- a/commands/package.js
+++ b/commands/package.js
@@ -62,18 +62,11 @@ exports.builder = (yargs) => {
     yargs.default('token', defaults.token, defaults.token ? '######' : '');
 
     yargs.example(`eik package`);
+    yargs.example(`eik publish`);
     yargs.example(`eik package patch`);
-    yargs.example(`eik package minor --major 1`);
-    yargs.example(`eik package patch --major 1 --js ./assets/client.js --css ./assets/styles.css`);
-    yargs.example(`eik package patch --name my-app`);
-    yargs.example(`eik pkg patch --name my-app`);
-    yargs.example(`eik pkg --name my-app --server https://assets.myeikserver.com`);
-    yargs.example(`eik pkg --dry-run`);
+    yargs.example(`eik publish --dry-run`);
     yargs.example(`eik pkg --token ######`);
-    yargs.example(`eik pkg --map https://server/my-map1.json`);
-    yargs.example(`eik pkg --map https://server/my-map1.json --map https://server/my-map2.json`);
     yargs.example(`eik pkg --debug`);
-    yargs.example(`eik pkg -s https://assets.myeikserver.com -t ###### --name my-app --js ./assets/client.js --css ./assets/styles.css`);
 };
 
 exports.handler = async (argv) => {

--- a/test/integration/package.test.js
+++ b/test/integration/package.test.js
@@ -52,6 +52,7 @@ test('eik package : package, details provided by assets.json file', async (t) =>
         js: { input: join(__dirname, '..', 'fixtures', 'client.js') },
         css: { input: join(__dirname, '..', 'fixtures', 'styles.css') },
     };
+
     await fs.writeFile(
         join(t.context.folder, 'assets.json'),
         JSON.stringify(assets),


### PR DESCRIPTION
* enforces the presence of an assets.json file in the CWD when using the package/publish command
* aliases package to publish so you can run eik publish
* removes command line arguments for map, js, css, name and server when running the package/publish command