### PR TITLE
Add semantic release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Release and Publish
+
+on:
+ pull_request:
+ push:
+  branches: [ master ]
+
+jobs:
+ test:
+  runs-on: ubuntu-latest
+  steps:
+  - name: Checkout
+    uses: actions/checkout@v2
+  - name: Setup Node.js
+    uses: actions/setup-node@v1
+    with:
+      node-version: 12.x
+  - name: npm install
+    run: |
+      npm install
+  - name: npm lint
+    run: |
+      npm run lint
+  - name: npm test
+    run: |
+      npm test
+
+ release:
+  if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+  runs-on: ubuntu-latest
+  needs: [test]
+  steps:
+  - name: Checkout
+    uses: actions/checkout@v2
+  - name: Setup Node.js
+    uses: actions/setup-node@v1
+    with:
+      node-version: 12.x
+  - name: npm install
+    run: |
+      npm install
+  - name: npx semantic-release
+    run: |
+      npx semantic-release
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [10.x, 12.x]
+        node-version: [12.x, 14.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 13.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -28,3 +28,4 @@ jobs:
       - name: npm test
         run: |
           npm test
+  	CI: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [12.x, 13.x]
+        node-version: [12.x, 14.x]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -20,8 +20,11 @@ jobs:
           npm install
         env:
           CI: true
-      - name: Run tests
+      - name: npm lint
         run: |
-          npm run lint && npm test
+          npm run lint
         env:
           CI: true
+      - name: npm test
+        run: |
+          npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [12.x, 14.x]
+        node-version: [10.x, 12.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,15 @@
   "bin": {
     "eik": "index.js"
   },
+  "files": [
+    "CHANGELOG.md",
+    "package.json",
+    "readme.md",
+    "index.js",
+    "commands",
+    "classes",
+    "utils"
+  ],
   "scripts": {
     "test": "HTTP_PORT=0 LOG_LEVEL=fatal tap --timeout 0 test/*.test.js test/**/*.test.js",
     "lint:format": "eslint --fix .",
@@ -13,7 +22,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "@babel/core": "^7.9.6",
     "@babel/preset-env": "^7.9.6",
@@ -56,6 +65,12 @@
   "devDependencies": {
     "@eik/core": "1.0.0-alpha.17",
     "@eik/service": "1.0.0-alpha.12",
+    "@semantic-release/changelog": "^5.0.1",
+    "@semantic-release/commit-analyzer": "^8.0.1",
+    "@semantic-release/git": "^9.0.0",
+    "@semantic-release/github": "^7.0.7",
+    "@semantic-release/npm": "^7.0.5",
+    "@semantic-release/release-notes-generator": "^9.0.1",
     "eslint": "7.2.0",
     "eslint-config-airbnb-base": "14.1.0",
     "eslint-config-prettier": "6.11.0",
@@ -67,6 +82,7 @@
     "puppeteer": "3.1.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
+    "semantic-release": "^17.0.8",
     "tap": "14.10.7"
   }
 }

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      "@semantic-release/changelog",
+      ["@semantic-release/npm", {
+        "tarballDir": "release"
+      }],
+      ["@semantic-release/github", {
+        "assets": "release/*.tgz"
+      }],
+      "@semantic-release/git"
+    ],
+    "preset": "angular"
+}

--- a/renovate.json
+++ b/renovate.json
@@ -13,8 +13,6 @@
   {
     "depTypeList": ["devDependencies"],
     "schedule": ["before 4am on monday"],
-    "commitMessage": "Dev dependency {{depName}} updated to version {{newValue}}",
-    "prTitle": "Dev dependency update: {{depName}}",
     "automerge": true,
     "major": {
       "automerge": false


### PR DESCRIPTION
This adds semantic release making the process of curating a release, adding a change log and publishing to NPM fully automatic. No humans required.

Its worth noticing:

 * This setup adhere to the [Angular flavor of Conventional Commit].(https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines). 
 * Automatic releases is only cut on merge to master and is done through a github action. 
 * All updates to dependencies by renovate bot will trigger an automatic release of this module if tests passes. 
 * All updates to dev dependencies  by renovate bot will *NOT* trigger an automatic release of this module.
 * When a new version is automatically released, semantic release will update package.json with the version number and commit it back to git.

Merging this PR should not trigger a release btw.