### PR TITLE
fix: convert object to string for writeFileSync

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [12.x, 13.x, 14.x]
+        node-version: [12.x, 14.x]
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [12.x, 13.x]
+        node-version: [12.x, 13.x, 14.x]
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}

--- a/classes/publish/package/tasks/create-bundles.js
+++ b/classes/publish/package/tasks/create-bundles.js
@@ -118,7 +118,7 @@ module.exports = class CreateBundles extends Task {
                     fs.writeFileSync(join(path, 'main/index.css'), result.css);
                     fs.writeFileSync(
                         join(path, 'main/index.css.map'),
-                        result.map,
+                        String(result.map),
                     );
                 } else {
                     log.debug('CSS assets not specified');

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-terser": "^6.0.0",
     "semver": "^7.3.2",
+    "ssri": "^8.0.0",
     "tar": "^6.0.2",
     "temp-dir": "^2.0.0",
     "yargs": "^15.3.1",

--- a/utils/calculate-file-hash.js
+++ b/utils/calculate-file-hash.js
@@ -1,16 +1,9 @@
 'use strict';
 
-const crypto = require('crypto');
+const ssri = require('ssri');
 const fs = require('fs');
-const { pipeline } = require('stream');
 
-module.exports = path =>
-    new Promise((resolve, reject) => {
-        const hash = crypto.createHash('sha512');
-        const file = fs.createReadStream(path);
-
-        pipeline(file, hash, error => {
-            if (error) return reject(error);
-            return resolve(`sha512-${hash.digest('base64')}`);
-        });
-    });
+module.exports = async path => {
+    const integrity = await ssri.fromStream(fs.createReadStream(path));
+    return integrity.toString();
+}

--- a/utils/calculate-files-hash.js
+++ b/utils/calculate-files-hash.js
@@ -1,15 +1,14 @@
 'use strict';
 
-const crypto = require('crypto');
+const ssri = require('ssri');
 const fileHash = require('./calculate-file-hash');
 
 module.exports = async files => {
     const hashes = await Promise.all(files.map(fileHash));
-    const hasher = crypto.createHash('sha512');
-
+    const hasher = ssri.create();
     for (const hash of hashes.sort()) {
         hasher.update(hash);
     }
-
-    return `sha512-${hasher.digest('base64')}`;
+    const integrity = hasher.digest()
+    return integrity.toString();
 };


### PR DESCRIPTION
result.map is an object instance with a toString that produces a source map. This stringification used to happen automatically in node 13 and earlier. In node 14 it throws when it doesn't actually get a string so it is now necessary to first stringify the object before passing it to writeFileSync.