### PR TITLE
fix: do not cleanup tmp files on dry run

### DIFF
--- a/classes/publish/package/index.js
+++ b/classes/publish/package/index.js
@@ -102,11 +102,11 @@ module.exports = class PublishApp {
 
         if (this.dryRun) {
             await this.runDryRun.process(incoming, outgoing);
-        } else {
-            await this.uploadFiles.process(incoming, outgoing);
-            await this.saveMetafile.process(incoming, outgoing);
+            return outgoing;
         }
-
+            
+        await this.uploadFiles.process(incoming, outgoing);
+        await this.saveMetafile.process(incoming, outgoing);
         await this.cleanup.process(incoming, outgoing);
 
         return outgoing;


### PR DESCRIPTION
Dry run files were being cleaned up which meant there was no way to inspect produced files. This stops clean up for dry runs