### PR TITLE
fix: rename entrypoints to files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tmp/**/*
 coverage
 .vscode
 .eikrc
+test/.eik

--- a/classes/publish/package/index.js
+++ b/classes/publish/package/index.js
@@ -21,7 +21,7 @@ module.exports = class PublishApp {
         name,
         version = '1.0.0',
         map = [],
-        entrypoints,
+        files,
         dryRun = false,
         out = './.eik',
     } = {}) {
@@ -32,7 +32,7 @@ module.exports = class PublishApp {
         this.name = name;
         this.version = version;
         this.map = map;
-        this.entrypoints = entrypoints;
+        this.files = files;
         this.dryRun = dryRun;
         this.out = out;
         this.path = isAbsolute(out) ? out : join(cwd, out);
@@ -55,7 +55,7 @@ module.exports = class PublishApp {
 
         const incoming = {
             path: this.path,
-            entrypoints: this.entrypoints,
+            files: this.files,
             server: this.server,
             name: this.name,
             version: this.version,

--- a/classes/publish/package/tasks/check-bundle-sizes.js
+++ b/classes/publish/package/tasks/check-bundle-sizes.js
@@ -11,14 +11,14 @@ const Task = require('./task');
 
 module.exports = class CheckBundleSizes extends Task {
     async process(incoming = {}, outgoing = {}) {
-        const { entrypoints, cwd } = incoming;
+        const { files, cwd } = incoming;
         this.log.debug('Checking bundle file sizes');
         try {
-            if (entrypoints) {
-                for (const [key, val] of Object.entries(entrypoints)) {
+            if (files) {
+                for (const [key, val] of Object.entries(files)) {
                     const path = isAbsolute(val) ? val : join(cwd, val);
 
-                    const files = await new Promise((resolve, reject) =>
+                    const fls = await new Promise((resolve, reject) =>
                         glob(path, (err, f) => {
                             if (err) {
                                 reject(err);
@@ -28,7 +28,7 @@ module.exports = class CheckBundleSizes extends Task {
                         }),
                     );
 
-                    for (const file of files) {
+                    for (const file of fls) {
                         this.log.debug(
                             `  ==> entrypoint size (${key} => ${file}): ${bytes(
                                 gzipSize.sync(fs.readFileSync(file, 'utf8')),

--- a/classes/publish/package/tasks/check-if-already-published.js
+++ b/classes/publish/package/tasks/check-if-already-published.js
@@ -6,12 +6,12 @@ const { join } = require('path');
 const { integrity, versions } = require('../../../../utils/http');
 const hash = require('../../../../utils/hash');
 const Task = require('./task');
-const { entrypoints: mapEntrypoints } = require('../../../../utils');
+const { files: mapfiles } = require('../../../../utils');
 
 module.exports = class CheckIfAlreadyPublished extends Task {
     async process(incoming = {}, outgoing = {}) {
         const { log } = this;
-        const { server, name, version, entrypoints, path, cwd } = incoming;
+        const { server, name, version, files, path, cwd } = incoming;
 
         log.debug(`Checking for existence of package ${name} version ${version}`);
         log.debug('  ==> Fetching package metadata from server');
@@ -50,8 +50,8 @@ module.exports = class CheckIfAlreadyPublished extends Task {
         let localHash;
         try {
             const localFiles = [join(path, './eik.json')];
-            if (entrypoints) {
-                const mappings = await mapEntrypoints(entrypoints, path, {
+            if (files) {
+                const mappings = await mapfiles(files, path, {
                     cwd,
                 });
 

--- a/classes/publish/package/tasks/create-zip-file.js
+++ b/classes/publish/package/tasks/create-zip-file.js
@@ -7,14 +7,14 @@ const fs = require('fs');
 const { join, resolve, basename, dirname } = require('path');
 const tar = require('tar');
 const Task = require('./task');
-const { entrypoints: mapEntrypoints } = require('../../../../utils');
+const { files: mapfiles } = require('../../../../utils');
 
 const { copyFileSync, writeFileSync } = fs;
 
 module.exports = class CreateZipFile extends Task {
     async process(incoming = {}, outgoing = {}) {
         const { log } = this;
-        const { entrypoints, path, name, map, server, out, cwd } = incoming;
+        const { files, path, name, map, server, out, cwd } = incoming;
 
         log.debug(`Creating zip file`);
         log.debug(`  ==> ${join(path, `eik.tgz`)}`);
@@ -29,7 +29,7 @@ module.exports = class CreateZipFile extends Task {
                     {
                         name,
                         server,
-                        entrypoints,
+                        files,
                         'import-map': map,
                         out,
                     },
@@ -42,9 +42,9 @@ module.exports = class CreateZipFile extends Task {
             throw new Error(`Failed to zip eik.json file: ${err.message}`);
         }
 
-        if (entrypoints) {
+        if (files) {
             try {
-                const mappings = await mapEntrypoints(entrypoints, path, {
+                const mappings = await mapfiles(files, path, {
                     cwd,
                 });
 

--- a/classes/publish/package/tasks/dry-run.js
+++ b/classes/publish/package/tasks/dry-run.js
@@ -3,20 +3,20 @@
 'use strict';
 
 const Task = require('./task');
-const { entrypoints: mapEntrypoints } = require('../../../../utils');
+const { files: mapfiles } = require('../../../../utils');
 
 module.exports = class DryRun extends Task {
     async process(incoming = {}, outgoing = {}) {
-        const { dryRun, path, zipFile, entrypoints, cwd } = incoming;
+        const { dryRun, path, zipFile, files, cwd } = incoming;
         if (dryRun) {
             outgoing.files = [
                 { pathname: path, type: 'temporary directory' },
                 { pathname: zipFile, type: 'package archive' },
             ]
 
-            const files = await mapEntrypoints(entrypoints, path, { cwd });
+            const fls = await mapfiles(files, path, { cwd });
 
-            for (const [, dest] of files) {
+            for (const [, dest] of fls) {
                 outgoing.files.push({ pathname: dest, type: 'package file' });
             }
         }

--- a/classes/publish/package/tasks/validate-input.js
+++ b/classes/publish/package/tasks/validate-input.js
@@ -19,7 +19,7 @@ class ValidationError extends Error {
 module.exports = class ValidateInput extends Task {
     process(incoming = {}, outgoing = {}) {
         const { log } = this;
-        const { cwd, server, name, entrypoints, map, dryRun, version } = incoming;
+        const { cwd, server, name, files, map, dryRun, version } = incoming;
 
         log.debug('Validating input');
 
@@ -51,13 +51,13 @@ module.exports = class ValidateInput extends Task {
             throw new ValidationError('Parameter "version" is not valid', err);
         }
 
-        if (!entrypoints) {
-            throw new ValidationError('Entrypoints must be provided');
+        if (!files) {
+            throw new ValidationError('files must be provided');
         }
 
-        log.debug(`  ==> entrypoints: ${JSON.stringify(entrypoints)}`);
-        if (typeof entrypoints !== 'object') {
-            throw new ValidationError('Parameter "entrypoints" is not valid');
+        log.debug(`  ==> files: ${JSON.stringify(files)}`);
+        if (typeof files !== 'object') {
+            throw new ValidationError('Parameter "files" is not valid');
         }
 
         log.debug(`  ==> map: ${JSON.stringify(map)}`);

--- a/classes/version.js
+++ b/classes/version.js
@@ -10,7 +10,7 @@ const mkdir = require('make-dir');
 const { validators } = require('@eik/common');
 const { integrity } = require('../utils/http');
 const hash = require('../utils/hash');
-const { entrypoints: mapEntrypoints } = require('../utils');
+const { files: mapfiles } = require('../utils');
 
 class ValidationError extends Error {
     constructor(message, err) {
@@ -30,7 +30,7 @@ module.exports = class Ping {
         version,
         level = 'patch',
         cwd,
-        entrypoints,
+        files,
         map,
         out = './.eik',
     } = {}) {
@@ -40,7 +40,7 @@ module.exports = class Ping {
         this.version = version;
         this.level = level;
         this.cwd = cwd;
-        this.entrypoints = entrypoints;
+        this.files = files;
         this.map = map;
         this.out = out;
         this.path = isAbsolute(out) ? out : join(cwd, out);
@@ -54,7 +54,7 @@ module.exports = class Ping {
             version,
             level,
             cwd,
-            entrypoints,
+            files,
             map,
             path,
             out,
@@ -95,9 +95,9 @@ module.exports = class Ping {
             throw new ValidationError('Parameter "version" is not valid');
         }
 
-        log.debug(`  ==> entrypoints: ${JSON.stringify(entrypoints)}`);
-        if (!entrypoints) {
-            throw new ValidationError('Parameter "entrypoints" is not valid');
+        log.debug(`  ==> files: ${JSON.stringify(files)}`);
+        if (!files) {
+            throw new ValidationError('Parameter "files" is not valid');
         }
 
         log.debug(`  ==> map: ${JSON.stringify(map)}`);
@@ -134,7 +134,7 @@ module.exports = class Ping {
             const eikJSON = {
                 name,
                 server,
-                entrypoints,
+                files,
                 'import-map': map,
                 out,
             };
@@ -143,9 +143,9 @@ module.exports = class Ping {
             const localFiles = [eikPathDest];
             log.debug(`  ==> ${eikPathDest}`);
 
-            if (entrypoints) {
+            if (files) {
                 try {
-                    const mappings = await mapEntrypoints(entrypoints, path, {
+                    const mappings = await mapfiles(files, path, {
                         cwd,
                     });
 

--- a/commands/init.js
+++ b/commands/init.js
@@ -85,7 +85,7 @@ exports.handler = async (argv) => {
                     name,
                     major,
                     server,
-                    entrypoints: {},
+                    files: {},
                 },
                 null,
                 2,

--- a/commands/package.js
+++ b/commands/package.js
@@ -64,7 +64,7 @@ exports.builder = (yargs) => {
 exports.handler = async (argv) => {
     const spinner = ora({ stream: process.stdout }).start('working...');
     const { debug, dryRun, cwd, token } = argv;
-    const {name, server, map, entrypoints, version, out} = getDefaults(cwd);
+    const {name, server, map, files, version, out} = getDefaults(cwd);
 
     try {
         try {
@@ -78,7 +78,7 @@ exports.handler = async (argv) => {
             name,
             server,
             map: Array.isArray(map) ? map : [map],
-            entrypoints,
+            files,
             version,
             cwd,
             token,
@@ -87,7 +87,7 @@ exports.handler = async (argv) => {
             out,
         };
 
-        const { files } = await new PublishPackage(options).run();
+        const { files: fls } = await new PublishPackage(options).run();
 
         if (!dryRun) {
             let url = new URL(join('pkg', name), server);
@@ -113,7 +113,7 @@ exports.handler = async (argv) => {
             process.stdout.write(`:: ${chalk.bgYellow.white.bold(' PACKAGE ')} > ${chalk.green(name)} | ${chalk.bold('dry run')}`);
             process.stdout.write('\n\n');
             process.stdout.write('   files (local temporary):\n');
-            for (const file of files) {
+            for (const file of fls) {
                 process.stdout.write(`   - ${chalk.bold('type')}: ${file.type}\n`);
                 process.stdout.write(`     ${chalk.bold('path')}: ${file.pathname}\n\n`);
             }

--- a/commands/version.js
+++ b/commands/version.js
@@ -62,7 +62,7 @@ exports.builder = (yargs) => {
 exports.handler = async (argv) => {
     const spinner = ora({ stream: process.stdout }).start('working...');
     const { level, debug, dryRun, cwd, token } = argv;
-    const { name, version, server, entrypoints, map, out } = getDefaults(cwd);
+    const { name, version, server, files, map, out } = getDefaults(cwd);
 
     try {
         try {
@@ -85,7 +85,7 @@ exports.handler = async (argv) => {
             dryRun,
             debug,
             level,
-            entrypoints,
+            files,
             map: Array.isArray(map) ? map : [map],
             out,
         };

--- a/test/alias.test.js
+++ b/test/alias.test.js
@@ -45,7 +45,7 @@ test('Creating a package alias', async t => {
     await new cli.publish.Package({
         server: address,
         name: 'my-pack',
-        entrypoints: {
+        files: {
             './index.js': join(__dirname, './fixtures/client.js'),
             './index.css': join(__dirname, './fixtures/styles.css'),
         },

--- a/test/integration/alias.test.js
+++ b/test/integration/alias.test.js
@@ -75,7 +75,7 @@ test('eik package-alias <name> <version> <alias>', async t => {
     await new cli.publish.Package({
         server: address,
         name: 'my-pack',
-        entrypoints: {
+        files: {
             './index.js': join(__dirname, '../fixtures/client.js'),
             './index.css': join(__dirname, '../fixtures/styles.css'),
         },

--- a/test/integration/init.test.js
+++ b/test/integration/init.test.js
@@ -30,9 +30,9 @@ test('Initializing a new eik.json file', async t => {
     t.equals(assets.major, 1, 'eik.json "major" field should equal 1');
     t.equals(assets.server, '', 'eik.json "server" field should be empty');
     t.same(
-        assets.entrypoints,
+        assets.files,
         {},
-        'eik.json "entrypoints" should be an empty object',
+        'eik.json "files" should be an empty object',
     );
 });
 
@@ -67,7 +67,7 @@ test('Initializing a new eik.json file passing custom values', async t => {
         'eik.json "server" field should not be empty',
     );
     t.same(
-        assets.entrypoints,
+        assets.files,
         {},
         'eik.json "js.input" field should not be empty',
     );

--- a/test/integration/integrity.test.js
+++ b/test/integration/integrity.test.js
@@ -49,7 +49,7 @@ test('eik meta : details provided by eik.json', async (t) => {
         name: 'test-app',
         version: '1.0.0',
         server: t.context.address,
-        entrypoints: {
+        files: {
             './index.js': join(__dirname, './../fixtures/client.js'),
             './index.css': join(__dirname, './../fixtures/styles.css'),
         },

--- a/test/integration/package.test.js
+++ b/test/integration/package.test.js
@@ -50,7 +50,7 @@ test('eik package : package, details provided by eik.json file', async (t) => {
         name: 'test-app',
         version: '1.0.0',
         server: t.context.address,
-        entrypoints: {
+        files: {
             './index.js': join(__dirname, './../fixtures/client.js'),
             './index.css': join(__dirname, './../fixtures/styles.css'),
         },
@@ -125,7 +125,7 @@ test('workflow: publish npm, alias npm, publish map, alias map and then publish 
         name: 'test-app',
         version: '1.0.0',
         server: t.context.address,
-        entrypoints: {
+        files: {
             './index.js': join(__dirname, './../fixtures/client-with-bare-imports.js'),
             './index.css': join(__dirname, './../fixtures/styles.css'),
         },

--- a/test/integration/react/react.test.js
+++ b/test/integration/react/react.test.js
@@ -135,7 +135,7 @@ beforeEach(async (done, t) => {
         cwd,
         server: address,
         name: 'my-app',
-        entrypoints: {
+        files: {
             './index.js': join(__dirname, './client.js'),
         },
         map: [new URL('/map/my-map/v1', address).href],

--- a/test/integrity.test.js
+++ b/test/integrity.test.js
@@ -40,7 +40,7 @@ test('package integrity', async (t) => {
         cwd: __dirname,
         server: address,
         name: 'my-app',
-        entrypoints: {
+        files: {
             './index.js': join(__dirname, './fixtures/client.js'),
             './index.css': join(__dirname, './fixtures/styles.css'),
         },

--- a/test/publish.package.test.js
+++ b/test/publish.package.test.js
@@ -43,7 +43,7 @@ test('Uploading app assets to an asset server', async t => {
         cwd: __dirname,
         server: address,
         name: 'my-app',
-        entrypoints: {
+        files: {
             './index.js': join(__dirname, './fixtures/client.js'),
             './index.css': join(__dirname, './fixtures/styles.css'),
         },
@@ -71,7 +71,7 @@ test('Uploading JS app assets only to an asset server', async t => {
         cwd: __dirname,
         server: address,
         name: 'my-app',
-        entrypoints: {
+        files: {
             './index.js': join(__dirname, './fixtures/client.js'),
         },
         debug: true,
@@ -98,7 +98,7 @@ test('Uploading CSS app assets only to an asset server', async t => {
         cwd: __dirname,
         server: address,
         name: 'my-app',
-        entrypoints: {
+        files: {
             './index.css': './fixtures/styles.css',
         },
         debug: true,
@@ -125,7 +125,7 @@ test('Uploading a directory of assets to an asset server', async t => {
         cwd: __dirname,
         server: address,
         name: 'my-app',
-        entrypoints: {
+        files: {
             './icons': './fixtures/icons/**/*',
         },
         debug: true,
@@ -152,7 +152,7 @@ test('Uploading a directory of assets to the root path to an asset server 2', as
         cwd: __dirname,
         server: address,
         name: 'my-app',
-        entrypoints: {
+        files: {
             '/': './fixtures/icons/**/*',
         },
         debug: true,

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -8,7 +8,7 @@ const fastify = require('fastify');
 const j = require('../utils/json');
 const h = require('../utils/hash');
 const f = require('../utils/http');
-const entrypoints = require('../utils/entrypoints');
+const files = require('../utils/files');
 
 test('calculate file hash', async (t) => {
     const hash = await h.file(
@@ -315,37 +315,37 @@ test('read JSON file - string - file absolute path', async (t) => {
     t.equal(json.key, 'val', 'Key should equal val');
 });
 
-test('entrypoints: basic mapping dest path to file source', async (t) => {
+test('files: basic mapping dest path to file source', async (t) => {
     const cwd = join(__dirname, 'tmp');
     const path = join(cwd, '.eik');
     const src = join(__dirname, './fixtures/client.js');
     const dest = join(path, './index.js');
 
-    const map = await entrypoints({ './index.js': src }, path, { cwd });
+    const map = await files({ './index.js': src }, path, { cwd });
 
     t.equal(map.get(src), dest, 'File source should point to destination');
 });
 
-test('entrypoints: error thrown when glob used with specific file mapping', async (t) => {
+test('files: error thrown when glob used with specific file mapping', async (t) => {
     const cwd = join(__dirname, 'tmp');
     const path = join(cwd, '.eik');
     const src = join(__dirname, './**/client.js');
 
-    t.rejects(async () => entrypoints({ './index.js': src }, path, { cwd }));
+    t.rejects(async () => files({ './index.js': src }, path, { cwd }));
 });
 
-test('entrypoints: matching dest path to file source', async (t) => {
+test('files: matching dest path to file source', async (t) => {
     const cwd = join(__dirname, 'tmp');
     const path = join(cwd, '.eik');
     const src1 = join(__dirname, './fixtures/client.js');
     const dest1 = join(path, './src/client.js');
 
-    const map = await entrypoints({ './src': '../fixtures/client.js' }, path, { cwd });
+    const map = await files({ './src': '../fixtures/client.js' }, path, { cwd });
 
     t.equal(map.get(src1), dest1, 'File source should point to destination');
 });
 
-test('entrypoints: matching dest path to file source', async (t) => {
+test('files: matching dest path to file source', async (t) => {
     const cwd = join(__dirname, 'tmp');
     const path = join(cwd, '.eik');
     const src1 = join(__dirname, './fixtures/client.js');
@@ -353,13 +353,13 @@ test('entrypoints: matching dest path to file source', async (t) => {
     const dest1 = join(path, './src/client.js');
     const dest2 = join(path, './src/client-with-bare-imports.js');
 
-    const map = await entrypoints({ './src': '../fixtures/*.js' }, path, { cwd });
+    const map = await files({ './src': '../fixtures/*.js' }, path, { cwd });
 
     t.equal(map.get(src1), dest1, 'File source should point to destination');
     t.equal(map.get(src2), dest2, 'File source should point to destination');
 });
 
-test('entrypoints: glob matching dest path to file source', async (t) => {
+test('files: glob matching dest path to file source', async (t) => {
     const cwd = join(__dirname, 'tmp');
     const path = join(cwd, '.eik');
     const src1 = join(__dirname, './fixtures/client.js');
@@ -367,13 +367,13 @@ test('entrypoints: glob matching dest path to file source', async (t) => {
     const dest1 = join(path, './src/fixtures/client.js');
     const dest2 = join(path, './src/integration/react/client.js');
 
-    const map = await entrypoints({ './src': '../**/client.js' }, path, { cwd });
+    const map = await files({ './src': '../**/client.js' }, path, { cwd });
 
     t.equal(map.get(src1), dest1, 'File source should point to destination');
     t.equal(map.get(src2), dest2, 'File source should point to destination');
 });
 
-test('entrypoints: glob matching dest path to file source, root path', async (t) => {
+test('files: glob matching dest path to file source, root path', async (t) => {
     const cwd = join(__dirname, 'tmp');
     const path = join(cwd, '.eik');
     const src1 = join(__dirname, './fixtures/client.js');
@@ -381,13 +381,13 @@ test('entrypoints: glob matching dest path to file source, root path', async (t)
     const dest1 = join(path, './fixtures/client.js');
     const dest2 = join(path, './integration/react/client.js');
 
-    const map = await entrypoints({ './': '../**/client.js' }, path, { cwd });
+    const map = await files({ './': '../**/client.js' }, path, { cwd });
 
     t.equal(map.get(src1), dest1, 'File source should point to destination');
     t.equal(map.get(src2), dest2, 'File source should point to destination');
 });
 
-test('entrypoints: glob matching dest path to file source, root path 2', async (t) => {
+test('files: glob matching dest path to file source, root path 2', async (t) => {
     const cwd = join(__dirname, 'tmp');
     const path = join(cwd, '.eik');
     const src1 = join(__dirname, './fixtures/client.js');
@@ -395,24 +395,24 @@ test('entrypoints: glob matching dest path to file source, root path 2', async (
     const dest1 = join(path, './fixtures/client.js');
     const dest2 = join(path, './integration/react/client.js');
 
-    const map = await entrypoints({ '/': '../**/client.js' }, path, { cwd });
+    const map = await files({ '/': '../**/client.js' }, path, { cwd });
 
     t.equal(map.get(src1), dest1, 'File source should point to destination');
     t.equal(map.get(src2), dest2, 'File source should point to destination');
 });
 
-test('entrypoints: glob matching dest path to file source, root path 2', async (t) => {
+test('files: glob matching dest path to file source, root path 2', async (t) => {
     const cwd = join(__dirname, 'tmp');
     const path = join(cwd, '.eik');
     const src1 = join(__dirname, './fixtures/client.js');
     const dest1 = join(path, './client.js');
 
-    const map = await entrypoints({ '/': '../fixtures/*.js' }, path, { cwd });
+    const map = await files({ '/': '../fixtures/*.js' }, path, { cwd });
 
     t.equal(map.get(src1), dest1, 'File source should point to destination');
 });
 
-test('entrypoints: glob matching dest path to file source, root path 3', async (t) => {
+test('files: glob matching dest path to file source, root path 3', async (t) => {
     const cwd = join(__dirname, 'tmp');
     const path = join(cwd, '.eik');
     const src1 = join(__dirname, './fixtures/client.js');
@@ -420,30 +420,30 @@ test('entrypoints: glob matching dest path to file source, root path 3', async (
     const dest1 = join(path, './client.js');
     const dest2 = join(path, './client-with-bare-imports.js');
 
-    const map = await entrypoints({ '/': '../fixtures/*.js' }, path, { cwd });
+    const map = await files({ '/': '../fixtures/*.js' }, path, { cwd });
 
     t.equal(map.get(src1), dest1, 'File source should point to destination');
     t.equal(map.get(src2), dest2, 'File source should point to destination');
 });
 
-test('entrypoints: glob matching dest path to file source, root path 4', async (t) => {
+test('files: glob matching dest path to file source, root path 4', async (t) => {
     const cwd = join(__dirname, 'tmp');
     const path = join(cwd, '.eik');
     const src1 = join(__dirname, './fixtures/client.js');
     const dest1 = join(path, './client.js');
 
-    const map = await entrypoints({ '/': '../fixtures/client.js' }, path, { cwd });
+    const map = await files({ '/': '../fixtures/client.js' }, path, { cwd });
 
     t.equal(map.get(src1), dest1, 'File source should point to destination');
 });
 
-test('entrypoints: folder without *', async (t) => {
+test('files: folder without *', async (t) => {
     const cwd = join(__dirname, 'tmp');
     const path = join(cwd, '.eik');
     const src = join(__dirname, './fixtures/icons/checkbox-sprite.svg');
     const dest = join(path, './icons/checkbox-sprite.svg');
 
-    const map = await entrypoints({ '/icons': '../fixtures/icons/*' }, path, { cwd });
+    const map = await files({ '/icons': '../fixtures/icons/*' }, path, { cwd });
 
     t.equal(map.get(src), dest, 'File source should point to destination');
 });

--- a/utils/files.js
+++ b/utils/files.js
@@ -34,25 +34,25 @@ const globP = (path) => {
     );
 }
 
-module.exports = async (entrypoints, path, options = {}) => {
+module.exports = async (files, path, options = {}) => {
     const cwd = options.cwd || process.cwd();
     const fileMap = new Map();
-    for (const [key, val] of Object.entries(entrypoints)) {
+    for (const [key, val] of Object.entries(files)) {
         const pathSrc = isAbsolute(val) ? val : join(cwd, val);
-        const files = await globP(pathSrc);
+        const fls = await globP(pathSrc);
 
-        for (const file of files) {
+        for (const file of fls) {
             const segments = key.split('/');
             const last = segments[segments.length - 1];
             if (last.includes('.')) {
-                if (files.length > 1) {
+                if (fls.length > 1) {
                     throw new Error(
                         'Cannot specify a single file destination for multiple source files',
                     );
                 }
                 fileMap.set(file, join(path, key));
             } else {
-                const commonBase = calculateParentDir(files);
+                const commonBase = calculateParentDir(fls);
                 if (commonBase !== file) {
                     const bname = file.replace(commonBase, '');
                     fileMap.set(file, join(path, key, bname));

--- a/utils/get-defaults.js
+++ b/utils/get-defaults.js
@@ -41,7 +41,7 @@ module.exports = function getDefaults(cwd) {
         return {
             server: server || undefined,
             token: token || undefined, 
-            entrypoints: assets.entrypoints || undefined,
+            files: assets.files || undefined,
             version: assets.version || undefined,
             map: assets['import-map'] || [],
             name: assets.name || undefined,

--- a/utils/index.js
+++ b/utils/index.js
@@ -3,6 +3,6 @@
 const logger = require('./logger');
 const getDefaults = require('./get-defaults');
 const getCWD = require('./get-cwd');
-const entrypoints = require('./entrypoints');
+const files = require('./files');
 
-module.exports = { logger, getDefaults, getCWD, entrypoints };
+module.exports = { logger, getDefaults, getCWD, files };


### PR DESCRIPTION
As per suggestion from @stipsan I've renamed `entrypoints` to `files` in `eik.json`