### PR TITLE
fix: remove major field, replace with version in init command

### DIFF
--- a/commands/init.js
+++ b/commands/init.js
@@ -34,12 +34,10 @@ exports.builder = (yargs) => {
                 Eg. --cwd /path/to/save/to`,
             default: process.cwd(),
         },
-        major: {
-            alias: 'm',
-            describe: `Specify the semver major version field in "eik.json".
-                This should be a single integer. 
-                Eg. --major 2`,
-            default: 1,
+        version: {
+            alias: 'v',
+            describe: `Specify the semver version field in "eik.json". Eg. --version 1.0.0`,
+            default: '1.0.0',
         },
         name: {
             alias: 'n',
@@ -57,7 +55,7 @@ exports.builder = (yargs) => {
 
 exports.handler = async (argv) => {
     const spinner = ora({ stream: process.stdout }).start('working...');
-    const { name, major, server, cwd, debug } = argv;
+    const { name, version, server, cwd, debug } = argv;
     const pathname = join(cwd, './eik.json');
     const log = logger(spinner, debug);
     let assetFileExists = false;
@@ -83,7 +81,7 @@ exports.handler = async (argv) => {
             JSON.stringify(
                 {
                     name,
-                    major,
+                    version,
                     server,
                     files: {},
                 },

--- a/test/integration/init.test.js
+++ b/test/integration/init.test.js
@@ -27,7 +27,7 @@ test('Initializing a new eik.json file', async t => {
     );
 
     t.equals(assets.name, '', 'eik.json "name" field should be empty');
-    t.equals(assets.version, '1.0.0', 'eik.json "major" field should equal 1');
+    t.equals(assets.version, '1.0.0', 'eik.json "version" field should equal 1.0.0');
     t.equals(assets.server, '', 'eik.json "server" field should be empty');
     t.same(
         assets.files,

--- a/test/integration/init.test.js
+++ b/test/integration/init.test.js
@@ -59,7 +59,7 @@ test('Initializing a new eik.json file passing custom values', async t => {
     t.equals(
         assets.version,
         '2.0.0',
-        'eik.json "major" field should not be empty',
+        'eik.json "version" field should not be empty',
     );
     t.equals(
         assets.server,

--- a/test/integration/init.test.js
+++ b/test/integration/init.test.js
@@ -27,7 +27,7 @@ test('Initializing a new eik.json file', async t => {
     );
 
     t.equals(assets.name, '', 'eik.json "name" field should be empty');
-    t.equals(assets.major, 1, 'eik.json "major" field should equal 1');
+    t.equals(assets.version, '1.0.0', 'eik.json "major" field should equal 1');
     t.equals(assets.server, '', 'eik.json "server" field should be empty');
     t.same(
         assets.files,
@@ -43,7 +43,7 @@ test('Initializing a new eik.json file passing custom values', async t => {
     const publishCmd = `${eik} init 
         --cwd ${folder}
         --name custom-name
-        --major 2
+        --version 2.0.0
         --server http://localhost:4001`;
     await exec(publishCmd.split('\n').join(' '));
 
@@ -57,8 +57,8 @@ test('Initializing a new eik.json file passing custom values', async t => {
         'eik.json "name" field should not be empty',
     );
     t.equals(
-        assets.major,
-        2,
+        assets.version,
+        '2.0.0',
         'eik.json "major" field should not be empty',
     );
     t.equals(


### PR DESCRIPTION
Thought I had fixed this. Major is from the early days of Eik, we don't use it any more.

Fixes #178 