### PR TITLE
fix: expose version, fix ValidationError usage, add tests

### DIFF
--- a/classes/index.js
+++ b/classes/index.js
@@ -8,6 +8,7 @@ const PublishMap = require('./publish/map');
 const PublishPackage = require('./publish/package/index');
 const PublishNPM = require('./publish/npm');
 const Integrity = require('./integrity');
+const Version = require('./version');
 
 module.exports = {
     Ping,
@@ -15,6 +16,7 @@ module.exports = {
     Meta,
     Login,
     Integrity,
+    Version,
     publish: {
         Package: PublishPackage,
         Map: PublishMap,

--- a/classes/version.js
+++ b/classes/version.js
@@ -7,7 +7,7 @@ const { join, isAbsolute, parse } = require('path');
 const abslog = require('abslog');
 const semver = require('semver');
 const mkdir = require('make-dir');
-const { schemas, ValidationError } = require('@eik/common');
+const { schemas } = require('@eik/common');
 const { integrity } = require('../utils/http');
 const hash = require('../utils/hash');
 const { files: mapfiles } = require('../utils');
@@ -21,7 +21,7 @@ module.exports = class Ping {
         level = 'patch',
         cwd,
         files,
-        map,
+        map = [],
         out = './.eik',
     } = {}) {
         this.log = abslog(logger);
@@ -66,17 +66,17 @@ module.exports = class Ping {
 
         log.debug(`  ==> level: ${level}`);
         if (!['major', 'minor', 'patch'].includes(level)) {
-            throw new ValidationError('Parameter "version" is not valid');
+            throw new schemas.ValidationError('Parameter "version" is not valid');
         }
 
         log.debug(`  ==> files: ${JSON.stringify(files)}`);
         if (!files) {
-            throw new ValidationError('Parameter "files" is not valid');
+            throw new schemas.ValidationError('Parameter "files" is not valid');
         }
         
         log.debug(`  ==> map: ${JSON.stringify(map)}`);
         if (!Array.isArray(map)) {
-            throw new ValidationError('Parameter "map" is not valid');
+            throw new schemas.ValidationError('Parameter "map" is not valid');
         }
 
         log.debug('Checking local package version');

--- a/test/version.test.js
+++ b/test/version.test.js
@@ -1,0 +1,110 @@
+/* eslint-disable no-param-reassign */
+
+'use strict';
+
+const { join } = require('path');
+const { test, beforeEach, afterEach } = require('tap');
+const fastify = require('fastify');
+const EikService = require('@eik/service');
+const { sink } = require('@eik/core');
+const cli = require('..');
+
+beforeEach(async (done, t) => {
+    const memSink = new sink.MEM();
+    const server = fastify({ logger: false });
+    const service = new EikService({ customSink: memSink });
+    server.register(service.api());
+    const address = await server.listen();
+
+    const login = new cli.Login({
+        server: address,
+        key: 'change_me',
+    });
+    const token = await login.run();
+
+    t.context.server = server;
+    t.context.address = address;
+    t.context.token = token;
+    done();
+});
+
+afterEach(async (done, t) => {
+    await t.context.server.close();
+    done();
+});
+
+test('Current version unpublished - rejects with error', async t => {
+    const { address } = t.context;
+
+    try {
+        await new cli.Version({
+            cwd: __dirname,
+            server: address,
+            name: 'my-app',
+            files: {
+                './index.js': join(__dirname, './fixtures/client.js'),
+                './index.css': join(__dirname, './fixtures/styles.css'),
+            },
+            version: '1.0.0',
+        }).run();
+    } catch (err) {
+        t.equals(err.message, 'The current version of this package has not yet been published, version change is not needed.');
+    }
+});
+
+test('Current version published - files the same - rejects with error', async t => {
+    const { address, token } = t.context;
+
+    await new cli.publish.Package({
+        cwd: __dirname,
+        server: address,
+        name: 'my-app',
+        files: {
+            './index.js': join(__dirname, './fixtures/client.js'),
+            './index.css': join(__dirname, './fixtures/styles.css'),
+        },
+        token,
+        version: '1.0.0',
+    }).run();
+
+    try {
+        await new cli.Version({
+            cwd: __dirname,
+            server: address,
+            name: 'my-app',
+            files: {
+                './index.js': join(__dirname, './fixtures/client.js'),
+                './index.css': join(__dirname, './fixtures/styles.css'),
+            },
+            version: '1.0.0',
+        }).run();
+    } catch (err) {
+        t.equals(err.message, 'The current version of this package already contains these files, version change is not needed.');
+    }
+});
+
+test('Current version published - files changed - bumps version', async t => {
+    const { address, token } = t.context;
+
+    await new cli.publish.Package({
+        cwd: __dirname,
+        server: address,
+        name: 'my-app',
+        files: {
+            './index.js': join(__dirname, './fixtures/client.js'),
+            './index.css': join(__dirname, './fixtures/styles.css'),
+        },
+        token,
+        version: '1.0.0',
+    }).run();
+
+    const newVersion = await new cli.Version({
+        cwd: __dirname,
+        server: address,
+        name: 'my-app',
+        files: { './index.js': join(__dirname, './fixtures/client.js') },
+        version: '1.0.0',
+    }).run();
+
+    t.equals(newVersion, '1.0.1');
+});


### PR DESCRIPTION
Version command was not exposed publicly, and had no tests. This PR fixes those 2 issues.
In addition, the ValidationError class in `@eik/common` was being incorrectly referenced in the Version command so that is fixed as well