### PR TITLE
feat: auto detect and set values when performing package aliasing

### DIFF
--- a/classes/alias.js
+++ b/classes/alias.js
@@ -38,7 +38,7 @@ module.exports = class Alias {
         validators.alias(this.alias);
         assert(this.token && typeof this.token === 'string', `Parameter "token" is not valid`);
 
-        this.log.debug('Requesting alias creation from server');
+        this.log.debug(`Requesting creation of ${this.type} alias "v${this.alias}" for ${this.name} v${this.version}`);
         try {
             const { message } = await request({
                 host: this.server,

--- a/commands/package-alias.js
+++ b/commands/package-alias.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const ora = require('ora');
+const semver = require('semver');
 const Alias = require('../classes/alias');
 const { logger, getDefaults, getCWD } = require('../utils');
 const { Alias: AliasFormatter } = require('../formatters');
 
-exports.command = 'package-alias <name> <version> <alias>';
+exports.command = 'package-alias [name] [version] [alias]';
 
 exports.aliases = ['pkg-alias', 'pa'];
 
@@ -23,16 +24,19 @@ exports.builder = (yargs) => {
             describe:
                 'Name matching existing name for a package on Eik server',
             type: 'string',
+            default: defaults.name,
         })
         .positional('version', {
             describe:
                 'Version matching existing version for a package on Eik server',
             type: 'string',
+            default: defaults.version,
         })
         .positional('alias', {
             describe:
                 'Alias for a semver version. Must be the semver major component of version. Eg. 1.0.0 should be given as 1',
             type: 'string',
+            default: semver.major(defaults.version),
         });
 
     yargs.options({

--- a/commands/package-alias.js
+++ b/commands/package-alias.js
@@ -36,7 +36,7 @@ exports.builder = (yargs) => {
             describe:
                 'Alias for a semver version. Must be the semver major component of version. Eg. 1.0.0 should be given as 1',
             type: 'string',
-            default: semver.major(defaults.version),
+            default: defaults.version ? semver.major(defaults.version) : null,
         });
 
     yargs.options({


### PR DESCRIPTION
Sets the name, version and alias values from eik.json if not provided in the command itself.
This should make it easier to run the command on CI