### PR TITLE
Support eik in package json

### DIFF
--- a/commands/package.js
+++ b/commands/package.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { promises: fs, constants } = require('fs');
 const { join } = require('path');
 const fetch = require('node-fetch');
 const ora = require('ora');
@@ -67,12 +66,6 @@ exports.handler = async (argv) => {
     const {name, server, map, files, version, out} = getDefaults(cwd);
 
     try {
-        try {
-            await fs.access(join(cwd, 'eik.json'), constants.F_OK);
-        } catch(err) {
-            throw new Error('No eik.json file found in the current working directory. Please run eik init');
-        }
-
         const options = { 
             logger: logger(spinner, debug),
             name,

--- a/commands/version.js
+++ b/commands/version.js
@@ -65,14 +65,6 @@ exports.handler = async (argv) => {
     const { name, version, server, files, map, out } = getDefaults(cwd);
 
     try {
-        try {
-            await fs.access(join(cwd, 'eik.json'), constants.F_OK);
-        } catch (err) {
-            throw new Error(
-                'No eik.json file found in the current working directory. Please run eik init',
-            );
-        }
-
         const log = logger(spinner, debug);
 
         const options = {

--- a/commands/version.js
+++ b/commands/version.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { execSync } = require('child_process');
-const { promises: fs, constants } = require('fs');
 const { join } = require('path');
 const ora = require('ora');
 const VersionPackage = require('../classes/version');

--- a/utils/get-defaults.js
+++ b/utils/get-defaults.js
@@ -14,10 +14,24 @@ const { readFileSync, existsSync } = require('fs');
  */
 module.exports = function getDefaults(cwd) {
     try {
+        let assets = {};
+
+        // read values from package.json eik field
+        const pkgPath = join(cwd, './package.json');
+        if (existsSync(pkgPath)) {
+            const pkgFile = readFileSync(pkgPath) || '{}';
+            const pkgJSON = JSON.parse(pkgFile);
+            assets = pkgJSON.eik;
+            assets.name = pkgJSON.name;
+            assets.version = pkgJSON.version;
+        }
+
         // read eik.json in current dir
         const assetsPath = join(cwd, './eik.json');
-        const assetsFile = existsSync(assetsPath) ? readFileSync(assetsPath) : '{}';
-        const assets = JSON.parse(assetsFile);
+        if (existsSync(assetsPath)) {
+            const assetsFile = readFileSync(assetsPath) || '{}';
+            assets = { ...assets, ...JSON.parse(assetsFile) };
+        }
         
         // read .eikrc in users home directory
         const eikPath = join(homedir, '.eikrc');
@@ -31,7 +45,7 @@ module.exports = function getDefaults(cwd) {
             server = tokens.keys().next().value;
         }
         
-        // server value in eik.json always takes presedence
+        // server value in eik.json or package.json always takes presedence
         if (assets.server) {
             server = assets.server;
         }

--- a/utils/get-defaults.js
+++ b/utils/get-defaults.js
@@ -2,7 +2,7 @@
 
 const { join } = require('path');
 const homedir = require('os').homedir();
-const { readFileSync, existsSync } = require('fs');
+const { readFileSync } = require('fs');
 
 function readJSONSync(path) {
     try {


### PR DESCRIPTION
This PR makes it possible to specify Eik values using `package.json`

The package.json `name` and `version` fields are used for the Eik `name` and `version` values. All other values are specified using an `eik` key.

For example

```json
{
  "name": "test-app",
  "version": "1.0.0",
  "eik": { }
}
```

The `eik` key can be used to specify any other fields that are accepted by `eik.json`.

If an `eik.json` file is also present, values will be merged with `eik.json` winning in the case of a clash.