### PR TITLE
ci: Add semantic release slack integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "semantic-release": "17.3.4",
+    "semantic-release-slack-bot": "^1.7.0",
     "tap": "14.11.0"
   }
 }

--- a/release.config.js
+++ b/release.config.js
@@ -15,6 +15,13 @@ module.exports = {
                 assets: 'release/*.tgz',
             },
         ],
+   	[
+      	    'semantic-release-slack-bot',
+            {
+                notifyOnSuccess: true,
+                notifyOnFail: false
+            }
+        ],
         '@semantic-release/git',
     ],
     preset: 'angular',


### PR DESCRIPTION
This ads a semantic release plugin to ping a slack channel for when a new release of the client is cut.