### PR TITLE
fix: Standardize stored integrity file between publish and integrity command

### DIFF
--- a/classes/publish/package/index.js
+++ b/classes/publish/package/index.js
@@ -84,6 +84,7 @@ module.exports = class PublishApp {
             author: {},
             org: '',
             version: this.version,
+            response: {},
         };
 
         await this.validateInput.process(incoming, outgoing);

--- a/classes/publish/package/tasks/save-metafile.js
+++ b/classes/publish/package/tasks/save-metafile.js
@@ -8,16 +8,11 @@ module.exports = class SaveMetaFile extends Task {
     async process(incoming = {}, outgoing = {}) {
         const { log } = this;
         const { cwd, out } = incoming;
-        const { version, integrity } = outgoing;
         const filepath = join(out, 'integrity.json');
-
         log.debug('Saving integrity file');
         log.debug(`  ==> ${filepath}`);
         try {
-            const meta = await json.read({ cwd, filename: filepath });
-            meta.version = version;
-            meta.integrity = integrity;
-            await json.write(meta, { cwd, filename: filepath });
+            await json.write(outgoing.response, { cwd, filename: filepath });
         } catch (err) {
             throw new Error(`Unable to save integrity file [${filepath}]: ${err.message}`);
         }

--- a/classes/publish/package/tasks/upload-files.js
+++ b/classes/publish/package/tasks/upload-files.js
@@ -30,6 +30,7 @@ module.exports = class UploadFiles extends Task {
             outgoing.org = message.org;
             outgoing.files = message.files;
             outgoing.version = version;
+            outgoing.response = message;
 
         } catch (err) {
             log.error('Unable to upload zip file to server');


### PR DESCRIPTION
Currently there is a miss match between the integrity file stored when running the `publish` and `integrity` command. When a `publish` is run, the stored integrity file in the `./eik` folder looks like this:

```json
{
  "version": "1.0.0",
  "integrity": "sha512-I5dyMaKAWNG91Ncl+q00+4fiPT0+DOhQmf+TH6oVuDy7ZnkkPSGYDSRWBhLj+KS4uafFGgBDvXJqQzVXs+hjZA=="
}
```

When the `integrity` command is run the same file looks like his:

```json
{
  "name": "@finn-no/trygve-lit-test",
  "version": "1.0.0",
  "integrity": "sha512-I5dyMaKAWNG91Ncl+q00+4fiPT0+DOhQmf+TH6oVuDy7ZnkkPSGYDSRWBhLj+KS4uafFGgBDvXJqQzVXs+hjZA==",
  "files": {
    "/eik.json": "sha512-zHQjnDpMW7IKVyTpT9cOPT1+xhUSOcbgXj6qHCPSPu1CbQfgwDEsIniXU54zDIN71zqmxLSp3hfIljpt69ok0w==",
    "/lit-element.js": "sha512-cdFHVq6Pl20TZaZWsKG6vyjHIC60u4EjroyCkKugwiysQ/8TpxmyIKIBgZQTRTVMtvU6X9DRWU6Y0gwykHd1vQ==",
    "/lit-element.js.map": "sha512-FDmOM1X6uKIESmhnytJIx9l/6aE4yPvQKlww7C3EwKnck3kKvrGU5yvNaETQiyjbTymUTb6g67ykR/G38HUchg=="
  }
}
```

The file created when running `publish` is a hash of the uploaded package which we do not really have a use case for other than comparing package versions. For [SRI](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) we need the hash of the file(s) which is going to be referenced by the script tags in the html. The `integrity` command returns a file suitabl for that. Though I find no big reason to operate with two different formats in the same file or a format which differ from the structure returned by the [package version overview](https://eik.dev/docs/server_rest_api/#package-version-overview) on the server.

This PR align the version written by the two commands and writes the same format as served by the [package version overview](https://eik.dev/docs/server_rest_api/#package-version-overview) endpoint on the server.

NB: I do think we should make it possible to define `./eik` folder to a custom path. Not that it makes much sense in terms of usage for end users, but it would help a lot in writing tests. Currently its impossible to rely on checking whats written in the integrity file since all tests which publish will write such a file in the same location overriding each other. When tests run in parallel its impossible to check this file for whats written by each test. If the path where configurable each test could write to a random tmp sub folder.