### PR TITLE
fix: remove restrictions to publishing when files are same as previous version

### DIFF
--- a/classes/publish/package/index.js
+++ b/classes/publish/package/index.js
@@ -114,17 +114,6 @@ module.exports = class Publish {
             };
         }
 
-        let integrity;
-        try {
-            integrity = await this.checkIfAlreadyPublished.process();
-        } catch (err) {
-            // exit early if already published
-            this.log.debug(
-                `Determined that files have already been published. Additional information: ${err.message}`,
-            );
-            return null;
-        }
-
         const response = await this.uploadFiles.process(zipFile);
         await this.saveMetafile.process(response);
         await this.cleanup.process();
@@ -139,7 +128,6 @@ module.exports = class Publish {
             author: {},
             org: '',
             version: this.config.version,
-            integrity,
             ...response,
         };
     }


### PR DESCRIPTION
Why: Its frustrating to try to publish a new version you have explicitly set and have it fail because the system determines that the files are the same as the previous version.