### PR TITLE
ci: Slim down slack bot messages for pre-releases

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -18,12 +18,39 @@ module.exports = {
         [
             'semantic-release-slack-bot',
             {
-                notifyOnSuccess: true,
+                notifyOnSuccess: false,
                 notifyOnFail: false,
                 packageName: '@eik/cli',
-                onSuccessTemplate: {
-                    text: '$package_name is now available as version $npm_package_version - $repo_url',
-                },
+                branchesConfig: [
+                    {
+                        pattern: 'master',
+                        notifyOnSuccess: true,
+                        onSuccessTemplate: {
+                            text: '$package_name $npm_package_version is now available - $repo_url',
+                        },
+                    },
+                    {
+                        pattern: 'alpha',
+                        notifyOnSuccess: true,
+                        onSuccessTemplate: {
+                            text: '$package_name $npm_package_version (pre-release) is now available - $repo_url',
+                        },
+                    },
+                    {
+                        pattern: 'beta',
+                        notifyOnSuccess: true,
+                        onSuccessTemplate: {
+                            text: '$package_name $npm_package_version (pre-release) is now available - $repo_url',
+                        },
+                    },
+                    {
+                        pattern: 'next',
+                        notifyOnSuccess: true,
+                        onSuccessTemplate: {
+                            text: '$package_name $npm_package_version (pre-release) is now available - $repo_url',
+                        },
+                    },
+                ]
             }
         ],
         '@semantic-release/git',


### PR DESCRIPTION
Currently there is a difference in the slack boot messages for pre-releases and releases on main. Slim these down.