### PR TITLE
Allow usage of plugin prefix on @eik/service

### DIFF
--- a/classes/login.js
+++ b/classes/login.js
@@ -29,7 +29,7 @@ module.exports = class Login {
             const { message } = await request({
                 host: this.server,
                 method: 'POST',
-                pathname: '/auth/login',
+                pathname: 'auth/login',
                 data: { key: this.key },
             });
 


### PR DESCRIPTION
We need to to use Fastify plugin prefix https://www.fastify.io/docs/latest/Plugins/#route-prefixing-options and thus append pathname to host rather than replace.

In the current situation this request will erase the path and directly append `pathname` after hostname/prococol.

This proposal would append `auth/login` to the full server path given by the cli. If no plugin prefix is used, it will work with the default setup as it is today.

This proposal will allow:

```
eik login --server http://localhost:4001/with/some/prefix
```