### PR TITLE
better error messages on server upload

### DIFF
--- a/classes/publish/package/tasks/upload-files.js
+++ b/classes/publish/package/tasks/upload-files.js
@@ -33,26 +33,26 @@ module.exports = class UploadFiles extends Task {
             switch (err.statusCode) {
                 case 400:
                     throw new Error(
-                        'Client attempted to send an invalid URL parameter',
+                        `${err.statusCode}: Client attempted to send an invalid URL parameter`,
                     );
                 case 401:
-                    throw new Error('Client unauthorized with server');
+                    throw new Error(`${err.statusCode}: Client unauthorized with server`);
                 case 404:
-                    throw new Error('Client could not find server route');
+                    throw new Error(`${err.statusCode}: Client could not find server route`);
                 case 409:
                     throw new Error(
                         `Package with name "${name}" and version "${version}" already exists on server`,
                     );
                 case 415:
                     throw new Error(
-                        'Client attempted to send an unsupported file format to server',
+                        `${err.statusCode}: Client attempted to send an unsupported file format to server`,
                     );
                 case 502:
                     throw new Error(
-                        'Server was unable to write file to storage',
+                        `${err.statusCode}: Server was unable to write file to storage, ${err.message}`,
                     );
                 default:
-                    throw new Error('Server failed');
+                    throw new Error(`${err.statusCode}: Server failed, ${err.message}`);
             }
         }
     }


### PR DESCRIPTION
### Description

Sometimes asset uploads fails with error messages: 

`Error: Error: Server failed`

`Error: Error: Server was unable to write file to storage`

We need some more information about status code and message from the response to debug this.

